### PR TITLE
v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "netherview",
-    "version": "0.1.6",
+    "version": "0.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "netherview",
-            "version": "0.1.6",
+            "version": "0.2.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -14,7 +14,7 @@
                 "@emotion/styled": "^11.11.0",
                 "@fontsource/roboto": "^5.0.8",
                 "@hotjar/browser": "^1.0.9",
-                "@jorgenswiderski/tomekeeper-shared": "^1.0.12",
+                "@jorgenswiderski/tomekeeper-shared": "^1.0.13",
                 "@mui/icons-material": "^5.14.13",
                 "@mui/material": "^5.14.12",
                 "@sentry/nextjs": "^7.77.0",
@@ -1726,9 +1726,9 @@
             }
         },
         "node_modules/@jorgenswiderski/tomekeeper-shared": {
-            "version": "1.0.12",
-            "resolved": "https://npm.pkg.github.com/download/@jorgenswiderski/tomekeeper-shared/1.0.12/52c0db82d7d89787549e7beb65f9e09e00a5361e",
-            "integrity": "sha512-GErjdD8Y1gO/81S4/iZ1FguXX16GFvxLlUqTrwhDyc9Ad9cgXQ7SWN1BlEBU13qADWK/L4SCvUqL/C9gEK8pNQ==",
+            "version": "1.0.13",
+            "resolved": "https://npm.pkg.github.com/download/@jorgenswiderski/tomekeeper-shared/1.0.13/1fe77b7f325439e2601f9e5d63cf2f90f8cbf5ae",
+            "integrity": "sha512-2D+cJF12np0Lm4S+aXXNpaoqMu5t5fYNNgCM7A3wsjvM93kYUw1Su87EcCIZ3PqoQLfPN99evl1C2Y3d+5nTvg==",
             "license": "MIT",
             "dependencies": {
                 "crypto-js": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "netherview",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "A character planner for Baldur's Gate 3",
     "main": "src/pages/_app.tsx",
     "scripts": {
@@ -57,7 +57,7 @@
         "@emotion/styled": "^11.11.0",
         "@fontsource/roboto": "^5.0.8",
         "@hotjar/browser": "^1.0.9",
-        "@jorgenswiderski/tomekeeper-shared": "^1.0.12",
+        "@jorgenswiderski/tomekeeper-shared": "^1.0.13",
         "@mui/icons-material": "^5.14.13",
         "@mui/material": "^5.14.12",
         "@sentry/nextjs": "^7.77.0",

--- a/src/components/character-display/character-display-tabs.tsx
+++ b/src/components/character-display/character-display-tabs.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import DashboardIcon from '@mui/icons-material/Dashboard';
-import BoltIcon from '@mui/icons-material/Bolt';
 import ShieldIcon from '@mui/icons-material/Shield';
 import AutoGraphIcon from '@mui/icons-material/AutoGraph';
 import FlareIcon from '@mui/icons-material/Flare';
@@ -8,7 +7,8 @@ import { CharacteristicsTab } from './tabs/characteristics/characteristics-tab';
 import { EquipmentTab } from './tabs/equipment/equipment-tab';
 import { ProgressionTab } from './tabs/progression/progression-tab';
 import { OverviewTab } from './tabs/overview/overview-tab';
-import { ActionsTab } from './tabs/actions/actions-tab';
+// import BoltIcon from '@mui/icons-material/Bolt';
+// import { ActionsTab } from './tabs/actions/actions-tab';
 
 export const characterDisplayTabs = [
     {
@@ -23,11 +23,11 @@ export const characterDisplayTabs = [
         element: ProgressionTab,
         icon: <AutoGraphIcon />,
     },
-    {
-        label: 'Actions',
-        element: ActionsTab,
-        icon: <BoltIcon />,
-    },
+    // {
+    //     label: 'Actions',
+    //     element: ActionsTab,
+    //     icon: <BoltIcon />,
+    // },
     {
         label: 'Equipment',
         labelMobile: 'Items',

--- a/src/components/character-display/equipment/equipment-armor-icon.tsx
+++ b/src/components/character-display/equipment/equipment-armor-icon.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Box, BoxProps, Typography } from '@mui/material';
+import ShieldIcon from '@mui/icons-material/Shield';
+import styled from '@emotion/styled';
+import { IEquipmentItem } from '@jorgenswiderski/tomekeeper-shared/dist/types/equipment-item';
+
+const StyledBox = styled(Box)`
+    display: flex;
+    align-items: center;
+
+    width: 36px;
+    position: relative;
+`;
+
+const AcLabel = styled(Typography)`
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+`;
+
+interface EquipmentArmorIconProps extends BoxProps {
+    item: IEquipmentItem;
+}
+
+export function EquipmentArmorIcon({ item, ...rest }: EquipmentArmorIconProps) {
+    if (!item.bonusArmorClass && !item.baseArmorClass) {
+        return null;
+    }
+
+    return (
+        <StyledBox {...rest}>
+            <ShieldIcon fontSize="large" />
+            <AcLabel variant="body2" color="black">
+                {item.bonusArmorClass
+                    ? `+${item.bonusArmorClass}`
+                    : item.baseArmorClass}
+            </AcLabel>
+        </StyledBox>
+    );
+}

--- a/src/components/character-display/equipment/equipment-slot-card.tsx
+++ b/src/components/character-display/equipment/equipment-slot-card.tsx
@@ -10,6 +10,7 @@ import {
     CardMedia,
     TextField,
     CardMediaProps,
+    Box,
 } from '@mui/material';
 import styled from '@emotion/styled';
 import {
@@ -25,14 +26,47 @@ import { ItemTooltip } from '../../tooltips/item-tooltip';
 import { ItemColors } from '../../../models/items/types';
 import { WeaveImages } from '../../../api/weave/weave-images';
 
-const StyledDialog = styled(Dialog)``;
+const StyledDialog = styled(Dialog)`
+    @media (max-width: 768px) {
+        height: calc(100vh - 64px);
+    }
+`;
+
+const StyledDialogTitle = styled(DialogTitle)`
+    @media (max-width: 768px) {
+        padding: 1rem;
+    }
+`;
+
+const StyledDialogContent = styled(DialogContent)`
+    @media (max-width: 768px) {
+        padding: 0 0.75rem 0.75rem;
+    }
+`;
 
 const DialogBox = styled(Paper)`
     display: flex;
     flex-direction: column;
+    align-items: stretch;
     gap: 0.5rem;
 
     padding: 1rem;
+    overflow: hidden;
+
+    @media (max-width: 768px) {
+        padding: 0.75rem;
+    }
+`;
+
+const ItemBox = styled(Box)`
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    flex: 1;
+
+    overflow: auto;
+    min-height: 300px;
 `;
 
 const StyledCard = styled(Card, {
@@ -96,11 +130,13 @@ export function EquipmentSlotCard({
 
     const handleClick = async () => {
         setIsOpen(true);
-        setIsLoading(true);
 
         try {
-            const data = await WeaveApi.items.getEquipmentItemInfo(slot);
-            setItems(data);
+            if (items.length === 0) {
+                setIsLoading(true);
+                const data = await WeaveApi.items.getEquipmentItemInfo(slot);
+                setItems(data);
+            }
         } catch (err) {
             error(err);
         } finally {
@@ -161,8 +197,17 @@ export function EquipmentSlotCard({
                 open={isOpen}
                 onClose={() => setIsOpen(false)}
             >
-                <DialogTitle>{EquipmentSlot[slot]} Options</DialogTitle>
-                <DialogContent>
+                <StyledDialogTitle>
+                    {EquipmentSlot[slot]} Options
+                </StyledDialogTitle>
+                <StyledDialogContent
+                    sx={{
+                        overflow: 'hidden',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        flex: 1,
+                    }}
+                >
                     <DialogBox>
                         <TextField
                             variant="outlined"
@@ -172,19 +217,25 @@ export function EquipmentSlotCard({
                             onChange={(e) => setSearchInput(e.target.value)}
                             margin="normal"
                         />
-                        {isLoading && <BeatLoader />}
-                        {sortedItems.map((itemOption) => (
-                            <ItemDialogOption
-                                item={itemOption}
-                                elevation={3}
-                                onClick={() => {
-                                    onEquipItem(itemOption);
-                                    setIsOpen(false);
-                                }}
-                            />
-                        ))}
+                        <ItemBox>
+                            {isLoading && (
+                                <Box textAlign="center">
+                                    <BeatLoader />
+                                </Box>
+                            )}
+                            {sortedItems.map((itemOption) => (
+                                <ItemDialogOption
+                                    item={itemOption}
+                                    elevation={3}
+                                    onClick={() => {
+                                        onEquipItem(itemOption);
+                                        setIsOpen(false);
+                                    }}
+                                />
+                            ))}
+                        </ItemBox>
                     </DialogBox>
-                </DialogContent>
+                </StyledDialogContent>
             </StyledDialog>
         </>
     );

--- a/src/components/character-display/equipment/item-dialog-option.tsx
+++ b/src/components/character-display/equipment/item-dialog-option.tsx
@@ -11,11 +11,11 @@ import {
     Typography,
 } from '@mui/material';
 import { IEquipmentItem } from '@jorgenswiderski/tomekeeper-shared/dist/types/equipment-item';
-import ShieldIcon from '@mui/icons-material/Shield';
 import LazyLoad from 'react-lazyload';
 import { ItemTooltip } from '../../tooltips/item-tooltip';
 import { ItemColors } from '../../../models/items/types';
 import { WeaveImages } from '../../../api/weave/weave-images';
+import { EquipmentArmorIcon } from './equipment-armor-icon';
 
 const ItemContainer = styled(Card)`
     display: flex;
@@ -51,13 +51,6 @@ const CardIcon = styled(CardMedia)<
     }
 `;
 
-const AcLabel = styled(Typography)`
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-`;
-
 const ItemLabel = styled(Typography)`
     @media (max-width: 768px) {
         font-size: 1rem;
@@ -90,19 +83,7 @@ export function ItemDialogOption({ item, ...props }: ItemDialogOptionProps) {
                 </LazyLoad>
                 <ItemDetails>
                     <HeaderBox>
-                        {(item.baseArmorClass || item.bonusArmorClass) && (
-                            <Box
-                                position="relative"
-                                display="flex"
-                                alignItems="center"
-                            >
-                                <ShieldIcon fontSize="large" />
-                                <AcLabel variant="body2" color="black">
-                                    {item.baseArmorClass ??
-                                        `+${item.bonusArmorClass}`}
-                                </AcLabel>
-                            </Box>
-                        )}
+                        <EquipmentArmorIcon item={item} />
                         <ItemLabel variant="h6" color={color}>
                             {item.name}
                         </ItemLabel>

--- a/src/components/character-display/tabs/actions/actions-tab.tsx
+++ b/src/components/character-display/tabs/actions/actions-tab.tsx
@@ -1,13 +1,12 @@
 import React, { useMemo } from 'react';
 import { ActionEffectType } from '@jorgenswiderski/tomekeeper-shared/dist/types/grantable-effect';
-import { ISpell } from '@jorgenswiderski/tomekeeper-shared/dist/types/action';
-import { Box, Paper } from '@mui/material';
+import { Paper } from '@mui/material';
 import { useCharacter } from '../../../../context/character-context/character-context';
 import { TabPanel } from '../../../simple-tabs/tab-panel';
 import { TabPanelProps } from '../../../simple-tabs/types';
-import { SpellsByLevel } from '../../../spells-by-level';
 import { GrantedEffects } from '../../../character-planner/feature-picker/prospective-effects/granted-effects';
 import { TabPanelItem } from '../../../simple-tabs/tab-panel-item';
+import { LearnedSpellsPanel } from './panels/learned-spells-panel';
 
 interface ActionsTabProps extends TabPanelProps {}
 
@@ -29,31 +28,17 @@ export function ActionsTab({ ...panelProps }: ActionsTabProps) {
 
     return (
         <TabPanel {...panelProps}>
-            <TabPanelItem
-                label="Learned Spells"
-                component={Paper}
-                componentProps={{ elevation: 2 }}
-            >
-                <Box
-                    sx={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: '0.5rem',
-                    }}
+            {spells.length > 0 && <LearnedSpellsPanel spells={spells} />}
+
+            {actions.length > 0 && (
+                <TabPanelItem
+                    label="Actions"
+                    component={Paper}
+                    componentProps={{ elevation: 2 }}
                 >
-                    <SpellsByLevel
-                        elevation={3}
-                        spells={spells.map((spell) => spell.action as ISpell)}
-                    />
-                </Box>
-            </TabPanelItem>
-            <TabPanelItem
-                label="Actions"
-                component={Paper}
-                componentProps={{ elevation: 2 }}
-            >
-                <GrantedEffects effects={actions} elevation={3} flex />
-            </TabPanelItem>
+                    <GrantedEffects effects={actions} elevation={3} flex />
+                </TabPanelItem>
+            )}
         </TabPanel>
     );
 }

--- a/src/components/character-display/tabs/actions/panels/learned-spells-panel.tsx
+++ b/src/components/character-display/tabs/actions/panels/learned-spells-panel.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ISpell } from '@jorgenswiderski/tomekeeper-shared/dist/types/action';
+import { Paper, Box } from '@mui/material';
+import { IActionEffect } from '@jorgenswiderski/tomekeeper-shared/dist/types/grantable-effect';
+import { TabPanelItem } from '../../../../simple-tabs/tab-panel-item';
+import { SpellsByLevel } from '../../../../spells-by-level';
+
+interface LearnedSpellsPanelProps {
+    spells: IActionEffect[];
+}
+
+export function LearnedSpellsPanel({ spells }: LearnedSpellsPanelProps) {
+    return (
+        <TabPanelItem
+            label="Learned Spells"
+            component={Paper}
+            componentProps={{ elevation: 2 }}
+        >
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '0.5rem',
+                }}
+            >
+                <SpellsByLevel
+                    elevation={3}
+                    spells={spells.map((spell) => spell.action as ISpell)}
+                />
+            </Box>
+        </TabPanelItem>
+    );
+}

--- a/src/components/character-display/tabs/characteristics/characteristics-tab.tsx
+++ b/src/components/character-display/tabs/characteristics/characteristics-tab.tsx
@@ -30,7 +30,10 @@ const labels: Record<string, CharacterPlannerStep[]> = {
         CharacterPlannerStep.CHOOSE_SUBCLASS,
         CharacterPlannerStep.SUBCLASS_FEATURE,
     ],
-    Racial: [CharacterPlannerStep.SET_RACE],
+    Racial: [
+        CharacterPlannerStep.SET_RACE,
+        CharacterPlannerStep.CHOOSE_SUBRACE,
+    ],
     Feats: [
         CharacterPlannerStep.FEAT,
         CharacterPlannerStep.FEAT_SUBCHOICE,

--- a/src/components/character-display/tabs/overview/panels/actions-panel.tsx
+++ b/src/components/character-display/tabs/overview/panels/actions-panel.tsx
@@ -4,6 +4,7 @@ import { ActionEffectType } from '@jorgenswiderski/tomekeeper-shared/dist/types/
 import { TabPanelItem } from '../../../../simple-tabs/tab-panel-item';
 import { useCharacter } from '../../../../../context/character-context/character-context';
 import { GrantedEffects } from '../../../../character-planner/feature-picker/prospective-effects/granted-effects';
+import { LearnedSpellsPanel } from '../../actions/panels/learned-spells-panel';
 
 export function ActionsPanel() {
     const { character } = useCharacter();
@@ -37,16 +38,8 @@ export function ActionsPanel() {
                     <GrantedEffects effects={actions} elevation={3} flex />
                 </TabPanelItem>
             )}
-            {spells.length > 0 && (
-                <TabPanelItem
-                    label="Learned Spells"
-                    component={Paper}
-                    componentProps={{ elevation: 2 }}
-                    // sx={{ marginTop: '1rem' }}
-                >
-                    <GrantedEffects effects={spells} elevation={3} flex />
-                </TabPanelItem>
-            )}
+
+            {spells.length > 0 && <LearnedSpellsPanel spells={spells} />}
         </>
     );
 }

--- a/src/components/tooltips/item-tooltip.tsx
+++ b/src/components/tooltips/item-tooltip.tsx
@@ -17,6 +17,7 @@ import { ItemColors } from '../../models/items/types';
 import { Utils } from '../../models/utils';
 import { BaseTooltip } from './base-tooltip';
 import { DamageText } from '../damage-text';
+import { EquipmentArmorIcon } from '../character-display/equipment/equipment-armor-icon';
 
 const GradientBox = styled(Box)<{ gradient: string }>`
     display: flex;
@@ -26,6 +27,10 @@ const GradientBox = styled(Box)<{ gradient: string }>`
     background: ${(props) => props.gradient};
     margin: -0.5rem;
     padding: 0.5rem;
+`;
+
+const StyledEquipmentArmorIcon = styled(EquipmentArmorIcon)`
+    float: right;
 `;
 
 const EffectName = styled.span`
@@ -117,10 +122,13 @@ export function ItemTooltip({ item, children }: ItemTooltipProps) {
                 </GradientBox>
             }
             body={
-                <>
+                <Box position="relative">
+                    <StyledEquipmentArmorIcon item={item} />
+
                     {weapon?.enchantment && (
                         <Typography variant="body2">{`Weapon Enchantment +${weapon.enchantment}`}</Typography>
                     )}
+
                     {item.effects
                         .filter((effect) => !effect.hidden)
                         .map((effect) => (
@@ -138,7 +146,7 @@ export function ItemTooltip({ item, children }: ItemTooltipProps) {
                                 </EffectDescription>
                             </Typography>
                         ))}
-                </>
+                </Box>
             }
             quote={
                 <Box


### PR DESCRIPTION
* Fix actions tab rendering empty action panels

* Group subrace passives on passives tab

* Show spellsbylevel in overview, disable actions tab for now since its mostly redundant

* Add empty state overlay to equipment panel(s), improve mobile styling of item dialog.

* Fix mobile equipment tab style

* Item dialog search bar always visible

* Add AC icon to item tooltip

* Fix item dialog making API request on every open, style tweaks,

* 0.2.1

* Remove commented out style

* Add placeholder labels for empty slots on equipment tab