### PR TITLE
Hide equipment panel in overview if its empty, move equipment overlay…

### DIFF
--- a/src/components/character-display/equipment/equipment-slots.tsx
+++ b/src/components/character-display/equipment/equipment-slots.tsx
@@ -1,5 +1,5 @@
 // equipment-slots.tsx
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Box, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import styled from '@emotion/styled';
@@ -165,36 +165,18 @@ const MainContainer = styled(Box)<{ compact?: boolean }>`
     }
 `;
 
-const EmptyStateOverlay = styled(Box)`
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    backdrop-filter: blur(10px);
-    z-index: 10;
-    cursor: pointer;
-`;
-
 interface EquipmentSlotsProps {
     compact?: boolean;
 }
 
 export function EquipmentSlots({ compact }: EquipmentSlotsProps) {
-    const { isMobile } = useResponsive();
     const { character, setCharacter } = useCharacter();
-
-    const [dismissedOverlay, setDismissedOverlay] = useState(false);
 
     const equipmentSlots = Object.keys(EquipmentSlot)
         .filter((key) => !Number.isNaN(Number(EquipmentSlot[key as any])))
         .map((key) => EquipmentSlot[key as keyof typeof EquipmentSlot]);
 
     const items = useMemo(() => character.getEquipment(), [character]);
-    const hasItems = equipmentSlots.some((slot) => items[slot]?.item);
 
     const onEquipItem = useCallback(
         (slot: EquipmentSlot, item: IEquipmentItem) => {
@@ -216,15 +198,6 @@ export function EquipmentSlots({ compact }: EquipmentSlotsProps) {
 
     return (
         <MainContainer compact={compact}>
-            {!hasItems && !dismissedOverlay && (
-                <EmptyStateOverlay onClick={() => setDismissedOverlay(true)}>
-                    <Typography variant="body1">
-                        No equipment yet, {isMobile ? 'tap' : 'click'} here to
-                        add some!
-                    </Typography>
-                </EmptyStateOverlay>
-            )}
-
             {compact ? (
                 <SlotsCompact
                     slots={equipmentSlots}

--- a/src/components/character-display/tabs/equipment/equipment-tab.tsx
+++ b/src/components/character-display/tabs/equipment/equipment-tab.tsx
@@ -1,18 +1,55 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import styled from '@emotion/styled';
+import { Box, Typography } from '@mui/material';
 import { TabPanel } from '../../../simple-tabs/tab-panel';
 import { TabPanelProps } from '../../../simple-tabs/types';
 import { EquipmentSlots } from '../../equipment/equipment-slots';
+import { useCharacter } from '../../../../context/character-context/character-context';
+import { useResponsive } from '../../../../hooks/use-responsive';
 
 const StyledTabPanel = styled(TabPanel)`
+    position: relative;
     column-gap: 0;
+`;
+
+const EmptyStateOverlay = styled(Box)`
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    backdrop-filter: blur(10px);
+    z-index: 10;
+    cursor: pointer;
 `;
 
 interface EquipmentTabProps extends TabPanelProps {}
 
 export function EquipmentTab({ ...panelProps }: EquipmentTabProps) {
+    const { isMobile } = useResponsive();
+    const { character } = useCharacter();
+
+    const [dismissedOverlay, setDismissedOverlay] = useState(false);
+
+    const hasAnyEquippedItems = useMemo(() => {
+        const items = character.getEquipment();
+
+        return Object.keys(items).length > 0;
+    }, [character]);
+
     return (
         <StyledTabPanel {...panelProps}>
+            {!hasAnyEquippedItems && !dismissedOverlay && (
+                <EmptyStateOverlay onClick={() => setDismissedOverlay(true)}>
+                    <Typography variant="body1">
+                        No equipment yet, {isMobile ? 'tap' : 'click'} here to
+                        add some!
+                    </Typography>
+                </EmptyStateOverlay>
+            )}
             <EquipmentSlots />
         </StyledTabPanel>
     );

--- a/src/components/character-display/tabs/overview/panels/equipment-panel.tsx
+++ b/src/components/character-display/tabs/overview/panels/equipment-panel.tsx
@@ -1,13 +1,26 @@
 // equipment-panel.tsx
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Paper } from '@mui/material';
 import styled from '@emotion/styled';
 import { TabPanelItem } from '../../../../simple-tabs/tab-panel-item';
 import { EquipmentSlots } from '../../../equipment/equipment-slots';
+import { useCharacter } from '../../../../../context/character-context/character-context';
 
 const StyledTabPanelItem = styled(TabPanelItem)``;
 
 export function EquipmentPanel() {
+    const { character } = useCharacter();
+
+    const hasAnyEquippedItems = useMemo(() => {
+        const items = character.getEquipment();
+
+        return Object.keys(items).length > 0;
+    }, [character]);
+
+    if (!hasAnyEquippedItems) {
+        return null;
+    }
+
     return (
         <StyledTabPanelItem
             label="Equipment"


### PR DESCRIPTION
… to the tab instead of the underlying component